### PR TITLE
Fix packaging for ubuntu builds

### DIFF
--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -39,6 +39,19 @@ build_deb() {
         echo "Warning: Binary not found in artifacts/$artifact_dir/"
         return 1
     fi
+    # Copy additional files for framework-dependent version
+    if [ "$package_type" = "framework-dependent" ]; then
+        find "artifacts/$artifact_dir" \
+            -name "*.dll" -o -name "*.so" -o -name "*.json" -o -name "*.pdb" | while read file; do
+            if [ -f "$file" ]; then
+                cp "$file" "$pkg_dir/usr/lib/aictionary/"
+            fi
+        done
+        # Copy Assets directory if exists
+        if [ -d "artifacts/$artifact_dir/Assets" ]; then
+            cp -r "artifacts/$artifact_dir/Assets" "$pkg_dir/usr/lib/aictionary/"
+        fi
+    fi
 
     # Create wrapper script
     cat > "$pkg_dir/usr/bin/Aictionary" << EOF


### PR DESCRIPTION
### Issue:
In the original packaging script, libraries (.so) and runtime files into /usr/bin instead of a dedicated library folder. This caused installed executables to fail at runtime (System.DllNotFoundException) because the dynamic linker could not find libSkiaSharp and other dependencies.

### Correction:

All runtime libraries (.dll, .so, .json, .pdb) and Assets are now copied to /usr/lib/aictionary.
/usr/bin/Aictionary is a small wrapper that sets LD_LIBRARY_PATH to point to /usr/lib/aictionary before launching the main executable.
This ensures both self-contained and framework-dependent packages can run correctly after installation.

### Test done:
basic test on ubuntu24.04, self-contained mode

### Orignal error

```
# Aictionary
Unhandled exception. System.TypeInitializationException: The type initializer for 'SkiaSharp.SKImageInfo' threw an exception.
 ---> System.DllNotFoundException: Unable to load shared library 'libSkiaSharp' or one of its dependencies. In order to help diagnose loading problems, consider using a tool like strace. If you're using glibc, consider setting the LD_DEBUG environment variable: 
/usr/bin/libSkiaSharp.so: cannot open shared object file: No such file or directory
/usr/bin/liblibSkiaSharp.so: cannot open shared object file: No such file or directory
/usr/bin/libSkiaSharp: cannot open shared object file: No such file or directory
/usr/bin/liblibSkiaSharp: cannot open shared object file: No such file or directory

   at SkiaSharp.SKImageInfo..cctor()
   --- End of inner exception stack trace ---
   at Avalonia.Skia.SkiaPlatform.Initialize(SkiaOptions options)
   at Avalonia.AppBuilder.SetupUnsafe()
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime(AppBuilder builder, String[] args, Action`1 lifetimeBuilder)
   at Aictionary.Program.Main(String[] args)
Aborted (core dumped)
```
