### PR TITLE
Fix the global shortcuts: silent failures, listener churn, platform modifiers

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- The quick query shortcut presses Command+C in whatever app is in
+	     front so it can look up the current selection. Sending that keystroke
+	     goes through System Events, which macOS gates behind Automation
+	     consent - without this key the request is denied outright and the
+	     user is never even asked. -->
+	<key>NSAppleEventsUsageDescription</key>
+	<string>AIctionary copies the text you have selected in other apps so it can look it up when you press the quick query shortcut.</string>
+</dict>
+</plist>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -103,6 +103,7 @@ pub fn run() {
             tts::list_edge_voices,
             // Shortcuts commands
             shortcuts::setup_shortcuts,
+            shortcuts::open_shortcut_permission_settings,
             // Tray commands
             set_tray_visibility,
         ])

--- a/src-tauri/src/shortcuts.rs
+++ b/src-tauri/src/shortcuts.rs
@@ -1,46 +1,82 @@
+use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager, Runtime};
 use tauri_plugin_clipboard_manager::ClipboardExt;
 
-/// Convert "Mod" to platform-specific modifier key and normalize special keys
+/// Map one stored modifier token onto what the hotkey parser expects.
+///
+/// Settings persist portable tokens so a config stays meaningful across
+/// platforms: `Mod` is the platform's primary accelerator (Command on macOS,
+/// Control elsewhere), while `Ctrl` and `Super` always mean the literal keys.
+fn normalize_token(token: &str) -> String {
+    match token.to_ascii_lowercase().as_str() {
+        "mod" => if cfg!(target_os = "macos") { "Command" } else { "Control" }.to_string(),
+        "ctrl" | "control" => "Control".to_string(),
+        "super" | "meta" | "cmd" | "command" => {
+            if cfg!(target_os = "macos") { "Command" } else { "Super" }.to_string()
+        }
+        "alt" | "option" => "Alt".to_string(),
+        "shift" => "Shift".to_string(),
+        // An empty segment is what "Mod+ " (a space binding) splits into.
+        "" => "Space".to_string(),
+        _ => token.to_string(),
+    }
+}
+
+/// Normalize a stored accelerator such as `Mod+Shift+K` into the
+/// platform-specific form the global shortcut plugin can parse.
 fn normalize_shortcut(shortcut: &str) -> String {
-    // First replace "Mod" with platform-specific key
-    #[cfg(target_os = "macos")]
-    let normalized = shortcut.replace("Mod", "Command");
+    shortcut
+        .split('+')
+        .map(|part| normalize_token(part.trim()))
+        .collect::<Vec<_>>()
+        .join("+")
+}
 
-    #[cfg(not(target_os = "macos"))]
-    let normalized = shortcut.replace("Mod", "Control");
-
-    // Handle space key - replace " " at the end or standalone with "Space"
-    // Split by + to handle each part
-    let parts: Vec<&str> = normalized.split('+').collect();
-    let normalized_parts: Vec<String> = parts
-        .iter()
-        .map(|part| {
-            let trimmed = part.trim();
-            if trimmed.is_empty() || trimmed == " " {
-                "Space".to_string()
-            } else {
-                trimmed.to_string()
-            }
-        })
-        .collect();
-
-    normalized_parts.join("+")
+/// Why a synthetic copy did not happen.
+///
+/// macOS needs both Automation (Apple Events) and Accessibility consent
+/// before it lets us press Command+C inside another app. The two denials are
+/// indistinguishable from the outside, so both map to `PermissionDenied` and
+/// the UI points at the one settings pane that fixes either.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CopyFailure {
+    PermissionDenied,
+    Unavailable,
 }
 
 /// Best-effort simulation of a copy shortcut (`Cmd+C` / `Ctrl+C`) in the
 /// currently active application so that the user's selection is placed
 /// on the clipboard before we read it.
-fn simulate_copy_shortcut() {
+fn simulate_copy_shortcut() -> Result<(), CopyFailure> {
     // macOS: use AppleScript to send Command+C to the frontmost app.
     #[cfg(target_os = "macos")]
     {
         use std::process::Command;
 
-        let _ = Command::new("osascript")
+        let output = Command::new("osascript")
             .arg("-e")
             .arg(r#"tell application "System Events" to keystroke "c" using {command down}"#)
-            .status();
+            .output()
+            .map_err(|_| CopyFailure::Unavailable)?;
+
+        if output.status.success() {
+            return Ok(());
+        }
+
+        // -1743 is "not authorised to send Apple events", -1719 is the
+        // assistive-access refusal; both mean the user has to grant consent.
+        let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+        if stderr.contains("-1743")
+            || stderr.contains("-1719")
+            || stderr.contains("not allowed")
+            || stderr.contains("not authorized")
+            || stderr.contains("assistive")
+        {
+            return Err(CopyFailure::PermissionDenied);
+        }
+
+        Err(CopyFailure::Unavailable)
     }
 
     // Windows: use PowerShell + WScript.Shell to send Ctrl+C.
@@ -51,7 +87,7 @@ fn simulate_copy_shortcut() {
 
         const CREATE_NO_WINDOW: u32 = 0x08000000;
 
-        let _ = Command::new("powershell")
+        let output = Command::new("powershell")
             .creation_flags(CREATE_NO_WINDOW)
             .args([
                 "-NoProfile",
@@ -59,7 +95,14 @@ fn simulate_copy_shortcut() {
                 "-Command",
                 r#"$wsh = New-Object -ComObject WScript.Shell; $wsh.SendKeys('^c')"#,
             ])
-            .status();
+            .output()
+            .map_err(|_| CopyFailure::Unavailable)?;
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(CopyFailure::Unavailable)
+        }
     }
 
     // Linux / other Unix: rely on xdotool if available.
@@ -67,7 +110,52 @@ fn simulate_copy_shortcut() {
     {
         use std::process::Command;
 
-        let _ = Command::new("xdotool").args(["key", "ctrl+c"]).status();
+        let output = Command::new("xdotool")
+            .args(["key", "ctrl+c"])
+            .output()
+            .map_err(|_| CopyFailure::Unavailable)?;
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(CopyFailure::Unavailable)
+        }
+    }
+}
+
+/// What the frontend receives when the quick query shortcut fires.
+///
+/// The window is raised either way; the payload only decides whether a
+/// lookup runs or the user gets told why nothing was picked up.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct QuickQueryPayload {
+    /// The text to look up, absent when the clipboard held nothing usable.
+    text: Option<String>,
+    /// Set when the synthetic copy failed, so the UI can explain itself.
+    copy_error: Option<CopyFailure>,
+}
+
+/// Per-shortcut registration outcome. Registration is attempted for both
+/// bindings independently so one bad accelerator cannot silently disable the
+/// other, and failures travel back to the UI instead of dying in a log line.
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShortcutSetupReport {
+    quick_query_error: Option<String>,
+    new_query_error: Option<String>,
+}
+
+/// Bring the main window forward.
+///
+/// `unminimize` has to come before `set_focus`: focusing a still-minimised
+/// window is a no-op, which used to leave the window restored but unfocused
+/// so the query bar never received the caret.
+fn focus_main_window<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
     }
 }
 
@@ -77,7 +165,7 @@ pub async fn setup_shortcuts<R: Runtime>(
     quick_query: String,
     new_query: String,
     enabled: bool,
-) -> Result<(), String> {
+) -> Result<ShortcutSetupReport, String> {
     use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
 
     let shortcuts = app.global_shortcut();
@@ -87,81 +175,137 @@ pub async fn setup_shortcuts<R: Runtime>(
         .unregister_all()
         .map_err(|e| format!("Failed to unregister shortcuts: {}", e))?;
 
+    let mut report = ShortcutSetupReport::default();
+
     if !enabled {
-      return Ok(());
+        return Ok(report);
     }
 
-    // Normalize shortcuts to replace "Mod" with platform-specific key
-    let quick_query_normalized = normalize_shortcut(&quick_query);
-    let new_query_normalized = normalize_shortcut(&new_query);
-
-    // Parse shortcuts
-    let quick_query_shortcut: Shortcut = quick_query_normalized.parse().map_err(|e| {
-        format!(
-            "Failed to parse quick query shortcut '{}': {}",
-            quick_query_normalized, e
-        )
-    })?;
-
-    let new_query_shortcut: Shortcut = new_query_normalized.parse().map_err(|e| {
-        format!(
-            "Failed to parse new query shortcut '{}': {}",
-            new_query_normalized, e
-        )
-    })?;
-
     // Register quick query shortcut (copy selected text + show window + search)
-    let app_handle = app.clone();
-    shortcuts
-        .on_shortcut(quick_query_shortcut, move |_app, _shortcut, event| {
-            if event.state == ShortcutState::Pressed {
+    match normalize_shortcut(&quick_query).parse::<Shortcut>() {
+        Ok(shortcut) => {
+            let app_handle = app.clone();
+            let registration = shortcuts.on_shortcut(shortcut, move |_app, _shortcut, event| {
+                if event.state != ShortcutState::Pressed {
+                    return;
+                }
+
                 let app_handle = app_handle.clone();
                 tauri::async_runtime::spawn(async move {
-                    // First, simulate the standard copy shortcut in the active application
-                    // so that the current selection is pushed to the clipboard.
-                    simulate_copy_shortcut();
+                    // Push the active app's selection onto the clipboard.
+                    // The helper shells out, so keep it off the async worker.
+                    let copy_error = tauri::async_runtime::spawn_blocking(simulate_copy_shortcut)
+                        .await
+                        .unwrap_or(Err(CopyFailure::Unavailable))
+                        .err();
 
-                    // Read from clipboard
+                    // Give the pasteboard a moment to settle.
                     tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
 
-                    if let Ok(clipboard_text) = app_handle.clipboard().read_text() {
-                        if !clipboard_text.trim().is_empty() {
-                            // Show the main window
-                            if let Some(window) = app_handle.get_webview_window("main") {
-                                let _ = window.show();
-                                let _ = window.set_focus();
-                                let _ = window.unminimize();
+                    let text = app_handle
+                        .clipboard()
+                        .read_text()
+                        .ok()
+                        .filter(|value| !value.trim().is_empty());
 
-                                // Emit event to frontend with the clipboard text
-                                let _ = app_handle.emit("quick-query", clipboard_text);
-                            }
-                        }
-                    }
+                    // Always surface the window: a silent no-op is
+                    // indistinguishable from the shortcut not working at all.
+                    focus_main_window(&app_handle);
+
+                    let _ = app_handle.emit("quick-query", QuickQueryPayload { text, copy_error });
                 });
+            });
+
+            if let Err(error) = registration {
+                report.quick_query_error = Some(error.to_string());
             }
-        })
-        .map_err(|e| format!("Failed to register quick query shortcut: {}", e))?;
+        }
+        Err(error) => {
+            report.quick_query_error = Some(error.to_string());
+        }
+    }
 
     // Register new query shortcut (show window + focus search box)
-    let app_handle = app.clone();
-    shortcuts
-        .on_shortcut(new_query_shortcut, move |_app, _shortcut, event| {
-            if event.state == ShortcutState::Pressed {
+    match normalize_shortcut(&new_query).parse::<Shortcut>() {
+        Ok(shortcut) => {
+            let app_handle = app.clone();
+            let registration = shortcuts.on_shortcut(shortcut, move |_app, _shortcut, event| {
+                if event.state != ShortcutState::Pressed {
+                    return;
+                }
+
                 let app_handle = app_handle.clone();
                 tauri::async_runtime::spawn(async move {
-                    // Show the main window and focus it
-                    if let Some(window) = app_handle.get_webview_window("main") {
-                        let _ = window.show();
-                        let _ = window.set_focus();
-                        let _ = window.unminimize();
-
-                        // Emit event to frontend to focus search box
-                        let _ = app_handle.emit("new-query", ());
-                    }
+                    focus_main_window(&app_handle);
+                    let _ = app_handle.emit("new-query", ());
                 });
-            }
-        })
-        .map_err(|e| format!("Failed to register new query shortcut: {}", e))?;
+            });
 
+            if let Err(error) = registration {
+                report.new_query_error = Some(error.to_string());
+            }
+        }
+        Err(error) => {
+            report.new_query_error = Some(error.to_string());
+        }
+    }
+
+    Ok(report)
+}
+
+/// Open the OS pane where the user grants the consent the quick query
+/// shortcut needs. Only macOS gates synthetic keystrokes this way.
+#[tauri::command]
+pub fn open_shortcut_permission_settings() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        use std::process::Command;
+
+        Command::new("open")
+            .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_Automation")
+            .status()
+            .map_err(|err| err.to_string())?;
+
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "macos"))]
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_shortcut;
+
+    #[test]
+    fn maps_mod_to_the_platform_accelerator() {
+        let expected = if cfg!(target_os = "macos") {
+            "Command+Shift+K"
+        } else {
+            "Control+Shift+K"
+        };
+        assert_eq!(normalize_shortcut("Mod+Shift+K"), expected);
+    }
+
+    #[test]
+    fn keeps_literal_control_distinct_from_mod() {
+        assert_eq!(normalize_shortcut("Ctrl+Shift+K"), "Control+Shift+K");
+    }
+
+    #[test]
+    fn normalizes_a_trailing_space_segment() {
+        assert_eq!(
+            normalize_shortcut("Mod+ "),
+            if cfg!(target_os = "macos") {
+                "Command+Space"
+            } else {
+                "Control+Space"
+            }
+        );
+    }
+
+    #[test]
+    fn leaves_plain_keys_alone() {
+        assert_eq!(normalize_shortcut("Alt+Enter"), "Alt+Enter");
+    }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,14 @@
 import { Outlet, NavLink, useNavigate } from "react-router";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
+import { formatShortcut, isMacPlatform } from "@/shared/lib/shortcuts";
+import type {
+  QuickQueryPayload,
+  ShortcutSetupReport,
+} from "@/shared/hooks/use-global-shortcuts";
 import { cn } from "@/lib/utils";
 import { useSettings } from "@/features/settings/hooks/use-settings";
 import { useDictionarySearch } from "@/features/main/hooks/use-dictionary-search";
@@ -31,23 +38,83 @@ export function AppLayout() {
     search(word);
   };
 
+  const focusQueryBar = useCallback(() => {
+    // Switch to the dictionary tab first, then ask the query bar in the
+    // header to take the caret via a window-level custom event.
+    navigate("/");
+    window.dispatchEvent(new CustomEvent("focus-search-input"));
+  }, [navigate]);
+
+  // The window is raised even when nothing could be copied, so the shortcut
+  // always does something visible; this explains why no lookup ran.
+  const handleQuickQuery = useCallback(
+    (payload: QuickQueryPayload) => {
+      if (payload.text) {
+        navigate("/");
+        search(payload.text);
+        return;
+      }
+
+      focusQueryBar();
+
+      if (payload.copyError === "permission_denied") {
+        toast.error(t("settings.keyboard.toast.copy_permission"), {
+          action: isMacPlatform()
+            ? {
+                label: t("settings.keyboard.toast.open_settings"),
+                onClick: () => {
+                  void invoke("open_shortcut_permission_settings").catch(
+                    (error) => {
+                      console.warn(
+                        "Failed to open permission settings:",
+                        error
+                      );
+                    }
+                  );
+                },
+              }
+            : undefined,
+        });
+      } else if (payload.copyError === "unavailable") {
+        toast.error(t("settings.keyboard.toast.copy_unavailable"));
+      } else {
+        toast.info(t("settings.keyboard.toast.copy_empty"));
+      }
+    },
+    [focusQueryBar, navigate, search, t]
+  );
+
+  // A shortcut the OS refused to register would otherwise look bound in
+  // settings while doing nothing at all.
+  const handleSetupReport = useCallback(
+    (report: ShortcutSetupReport) => {
+      if (report.quickQueryError) {
+        toast.error(
+          t("settings.keyboard.toast.register_failed", {
+            shortcut: formatShortcut(settings.keyboard.quickQuery).join(" "),
+          })
+        );
+      }
+      if (report.newQueryError) {
+        toast.error(
+          t("settings.keyboard.toast.register_failed", {
+            shortcut: formatShortcut(settings.keyboard.newQuery).join(" "),
+          })
+        );
+      }
+    },
+    [settings.keyboard.newQuery, settings.keyboard.quickQuery, t]
+  );
+
   // Global keyboard shortcuts are wired here so they work regardless of
   // which main tab (dictionary/statistics/settings) is currently active.
   useGlobalShortcuts({
     quickQuery: settings.keyboard.quickQuery,
     newQuery: settings.keyboard.newQuery,
     enabled: settings.keyboard.enabled,
-    onQuickQuery: (text) => {
-      // Ensure we're on the dictionary tab, then run the search.
-      navigate("/");
-      search(text);
-    },
-    onNewQuery: () => {
-      // Switch to the dictionary tab first, then ask the main page
-      // to focus the search input via a window-level custom event.
-      navigate("/");
-      window.dispatchEvent(new CustomEvent("focus-search-input"));
-    },
+    onQuickQuery: handleQuickQuery,
+    onNewQuery: focusQueryBar,
+    onSetupReport: handleSetupReport,
   });
 
   // React to tray menu "About" clicks by navigating to Settings → About.

--- a/src/components/ui/kbd-input.tsx
+++ b/src/components/ui/kbd-input.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 import { Kbd, KbdGroup } from "@/components/ui/kbd"
+import { formatShortcut, shortcutFromEvent } from "@/shared/lib/shortcuts"
 
 interface KbdInputProps extends Omit<React.ComponentProps<"input">, "onKeyDown" | "onChange"> {
   value?: string
@@ -15,38 +16,10 @@ function KbdInput({ className, value = "", onChange, onKeyDown, ...props }: KbdI
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     event.preventDefault()
 
-    const keys: string[] = []
-
-    // Add modifiers
-    if (event.ctrlKey || event.metaKey) {
-      keys.push("Mod")
-    }
-    if (event.shiftKey && event.key !== "Shift") {
-      keys.push("Shift")
-    }
-    if (event.altKey && event.key !== "Alt") {
-      keys.push("Alt")
-    }
-
-    // Add the main key (if it's not a modifier)
-    const key = event.key
-    if (!["Control", "Meta", "Shift", "Alt"].includes(key)) {
-      // Format the key name
-      let formattedKey = key
-      if (key === " ") {
-        formattedKey = "Space"
-      } else if (key.length === 1) {
-        formattedKey = key.toUpperCase()
-      } else {
-        // Capitalize first letter for keys like "Enter", "Escape", etc.
-        formattedKey = key.charAt(0).toUpperCase() + key.slice(1)
-      }
-      keys.push(formattedKey)
-    }
-
-    // Only update if we have a complete shortcut
-    if (keys.length > 0 && !["Shift", "Alt", "Mod"].includes(keys[keys.length - 1])) {
-      const shortcut = keys.join("+")
+    // Null while only modifiers are held, so a half-typed chord never
+    // overwrites the existing binding.
+    const shortcut = shortcutFromEvent(event)
+    if (shortcut) {
       onChange?.(shortcut)
     }
 
@@ -54,17 +27,18 @@ function KbdInput({ className, value = "", onChange, onKeyDown, ...props }: KbdI
     onKeyDown?.(event)
   }
 
-  // Parse the value and render as kbd elements
+  // Parse the value and render as kbd elements. The stored form is portable
+  // ("Mod+Shift+K"); what is shown is what this platform actually presses.
   const renderKbds = () => {
-    if (!value || value.trim() === "") {
+    const keys = formatShortcut(value)
+    if (keys.length === 0) {
       return null
     }
 
-    const keys = value.split("+")
     return (
       <KbdGroup className="gap-1">
         {keys.map((key, index) => (
-          <Kbd key={index}>{key === " " || key === "" ? "Space" : key}</Kbd>
+          <Kbd key={index}>{key}</Kbd>
         ))}
       </KbdGroup>
     )

--- a/src/features/settings/components/keyboard-tab.tsx
+++ b/src/features/settings/components/keyboard-tab.tsx
@@ -4,6 +4,8 @@ import { KbdInput } from "@/components/ui/kbd-input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { useSettings } from "@/features/settings/hooks/use-settings";
+import { defaultSettings } from "@/shared/state/settings";
+import { formatShortcut } from "@/shared/lib/shortcuts";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 
@@ -13,11 +15,14 @@ export function KeyboardTab() {
 
   const handleReset = () => {
     updateKeyboard({
-      quickQuery: "Mod+Enter",
-      newQuery: "Mod+Shift+K",
+      quickQuery: defaultSettings.keyboard.quickQuery,
+      newQuery: defaultSettings.keyboard.newQuery,
     });
     toast.success(t("settings.keyboard.toast.reset"));
   };
+
+  // Placeholders spell the defaults the way this platform presses them.
+  const placeholder = (value: string) => formatShortcut(value).join(" ");
 
   return (
     <div className="flex flex-col">
@@ -48,7 +53,7 @@ export function KeyboardTab() {
               id="shortcut-quick"
               value={settings.keyboard.quickQuery}
               onChange={(value) => updateKeyboard({ quickQuery: value })}
-              placeholder="Mod+Enter"
+              placeholder={placeholder(defaultSettings.keyboard.quickQuery)}
             />
           </div>
           <div className="grid gap-2">
@@ -57,7 +62,7 @@ export function KeyboardTab() {
               id="shortcut-new"
               value={settings.keyboard.newQuery}
               onChange={(value) => updateKeyboard({ newQuery: value })}
-              placeholder="Mod+Shift+K"
+              placeholder={placeholder(defaultSettings.keyboard.newQuery)}
             />
           </div>
           <Button variant="outline" onClick={handleReset}>

--- a/src/features/settings/hooks/use-settings.ts
+++ b/src/features/settings/hooks/use-settings.ts
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from "react";
 import {
   defaultSettings,
   normalizeAudioSettings,
+  normalizeKeyboardSettings,
   settingsAtom,
 } from "@/shared/state/settings";
 import {
@@ -30,7 +31,7 @@ export function useSettings() {
         cardTheme: normalizeCardTheme(current.anki?.cardTheme),
       },
       dictionary: { ...defaultSettings.dictionary, ...(current.dictionary ?? {}) },
-      keyboard: { ...defaultSettings.keyboard, ...(current.keyboard ?? {}) },
+      keyboard: normalizeKeyboardSettings(current.keyboard),
       about: { ...defaultSettings.about, ...(current.about ?? {}) },
       system: { ...defaultSettings.system, ...(current.system ?? {}) },
     }),

--- a/src/shared/hooks/use-global-shortcuts.ts
+++ b/src/shared/hooks/use-global-shortcuts.ts
@@ -1,13 +1,30 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+
+/** Why the synthetic copy behind a quick query did not happen. */
+export type CopyFailure = "permission_denied" | "unavailable";
+
+export type QuickQueryPayload = {
+  /** Text to look up; null when the clipboard held nothing usable. */
+  text: string | null;
+  copyError: CopyFailure | null;
+};
+
+/** Per-shortcut registration outcome reported by `setup_shortcuts`. */
+export type ShortcutSetupReport = {
+  quickQueryError: string | null;
+  newQueryError: string | null;
+};
 
 interface UseGlobalShortcutsOptions {
   quickQuery: string;
   newQuery: string;
   enabled: boolean;
-  onQuickQuery: (text: string) => void;
+  onQuickQuery: (payload: QuickQueryPayload) => void;
   onNewQuery: () => void;
+  /** Called after every registration attempt, including the failures. */
+  onSetupReport?: (report: ShortcutSetupReport) => void;
 }
 
 export function useGlobalShortcuts({
@@ -16,43 +33,72 @@ export function useGlobalShortcuts({
   enabled,
   onQuickQuery,
   onNewQuery,
+  onSetupReport,
 }: UseGlobalShortcutsOptions) {
+  // Callers pass inline closures, so their identity changes on every render.
+  // Depending on them directly would tear down and re-register the Tauri
+  // listeners each time - and because registration crosses the IPC boundary
+  // asynchronously, every one of those cycles left a window in which an
+  // emitted event had nobody listening and was dropped silently.
+  const handlers = useRef({ onQuickQuery, onNewQuery, onSetupReport });
+
   useEffect(() => {
-    // Setup shortcuts on mount and when shortcuts change
+    handlers.current = { onQuickQuery, onNewQuery, onSetupReport };
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
     const setupShortcuts = async () => {
       try {
-        await invoke("setup_shortcuts", {
+        const report = await invoke<ShortcutSetupReport>("setup_shortcuts", {
           quickQuery,
           newQuery,
           enabled,
         });
+        if (!cancelled) {
+          handlers.current.onSetupReport?.(report);
+        }
       } catch (error) {
         console.error("Failed to setup shortcuts:", error);
+        if (!cancelled) {
+          const message = String(error);
+          handlers.current.onSetupReport?.({
+            quickQueryError: message,
+            newQueryError: message,
+          });
+        }
       }
     };
 
-    setupShortcuts();
+    void setupShortcuts();
+
+    return () => {
+      cancelled = true;
+    };
   }, [quickQuery, newQuery, enabled]);
 
+  // Registered once for the lifetime of the app: the ref above keeps the
+  // callbacks current without re-subscribing.
   useEffect(() => {
-    // Listen for quick-query event (clipboard text)
-    const unlisten = listen<string>("quick-query", (event) => {
-      onQuickQuery(event.payload);
+    const pending = listen<QuickQueryPayload>("quick-query", (event) => {
+      handlers.current.onQuickQuery(event.payload);
+    });
+
+    // Chaining off the promise also covers unmounting before registration
+    // has finished crossing the IPC boundary.
+    return () => {
+      void pending.then((unlisten) => unlisten());
+    };
+  }, []);
+
+  useEffect(() => {
+    const pending = listen("new-query", () => {
+      handlers.current.onNewQuery();
     });
 
     return () => {
-      unlisten.then((fn) => fn());
+      void pending.then((unlisten) => unlisten());
     };
-  }, [onQuickQuery]);
-
-  useEffect(() => {
-    // Listen for new-query event (focus search box)
-    const unlisten = listen("new-query", () => {
-      onNewQuery();
-    });
-
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [onNewQuery]);
+  }, []);
 }

--- a/src/shared/lib/shortcuts.ts
+++ b/src/shared/lib/shortcuts.ts
@@ -1,0 +1,134 @@
+/**
+ * Accelerators are persisted in a portable form so one settings blob stays
+ * meaningful on every platform: `Mod` is the primary accelerator (Command on
+ * macOS, Control elsewhere), while `Ctrl` and `Super` name the literal keys.
+ * The Rust side resolves these tokens again in `shortcuts.rs` before handing
+ * them to the global shortcut plugin.
+ */
+
+/** Tokens that only qualify a shortcut rather than being its main key. */
+const MODIFIER_TOKENS = new Set(["Mod", "Ctrl", "Super", "Alt", "Shift"]);
+
+export function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+  return /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+}
+
+/** Symbols macOS users expect to see; other platforms spell things out. */
+const MAC_LABELS: Record<string, string> = {
+  Mod: "⌘",
+  Super: "⌘",
+  Ctrl: "⌃",
+  Alt: "⌥",
+  Shift: "⇧",
+  Enter: "↩",
+  Escape: "⎋",
+  Tab: "⇥",
+  Backspace: "⌫",
+  Delete: "⌦",
+  ArrowUp: "↑",
+  ArrowDown: "↓",
+  ArrowLeft: "←",
+  ArrowRight: "→",
+};
+
+const OTHER_LABELS: Record<string, string> = {
+  Mod: "Ctrl",
+  Super: "Win",
+  Ctrl: "Ctrl",
+  Alt: "Alt",
+  Shift: "Shift",
+  ArrowUp: "↑",
+  ArrowDown: "↓",
+  ArrowLeft: "←",
+  ArrowRight: "→",
+};
+
+/** Render one stored token the way the current platform writes it. */
+export function formatShortcutToken(token: string, isMac = isMacPlatform()): string {
+  const trimmed = token.trim();
+  if (!trimmed) {
+    return "Space";
+  }
+  const labels = isMac ? MAC_LABELS : OTHER_LABELS;
+  return labels[trimmed] ?? trimmed;
+}
+
+/** Split a stored accelerator into platform-appropriate display tokens. */
+export function formatShortcut(value: string, isMac = isMacPlatform()): string[] {
+  if (!value.trim()) {
+    return [];
+  }
+  return value.split("+").map((token) => formatShortcutToken(token, isMac));
+}
+
+/**
+ * Derive the main (non-modifier) token from a keyboard event.
+ *
+ * `event.code` is used rather than `event.key` because the latter reports the
+ * character the modifiers produced - Alt+K on macOS arrives as "˚", which no
+ * hotkey parser accepts. Codes such as `Enter`, `Space`, `ArrowUp` or
+ * `BracketLeft` pass straight through; letters and digits are shortened to
+ * the bare character. Returns null while only modifiers are held.
+ */
+export function mainKeyFromEvent(event: {
+  code: string;
+  key: string;
+}): string | null {
+  if (["Control", "Meta", "Shift", "Alt", "CapsLock"].includes(event.key)) {
+    return null;
+  }
+
+  const { code } = event;
+  if (/^Key[A-Z]$/.test(code)) {
+    return code.slice(3);
+  }
+  if (/^Digit[0-9]$/.test(code)) {
+    return code.slice(5);
+  }
+  if (code === "NumpadEnter") {
+    return "Enter";
+  }
+  if (code) {
+    return code;
+  }
+
+  // Virtual keyboards and IME input can leave `code` empty; fall back to the
+  // character itself so the field is not simply unusable there.
+  return event.key === " " ? "Space" : event.key.toUpperCase();
+}
+
+/**
+ * Build the stored accelerator for a keypress, or null when the user is
+ * still only holding modifiers.
+ */
+export function shortcutFromEvent(
+  event: { code: string; key: string; ctrlKey: boolean; metaKey: boolean; altKey: boolean; shiftKey: boolean },
+  isMac = isMacPlatform()
+): string | null {
+  const mainKey = mainKeyFromEvent(event);
+  if (!mainKey || MODIFIER_TOKENS.has(mainKey)) {
+    return null;
+  }
+
+  const tokens: string[] = [];
+  // Command and Control are distinct keys; conflating them made it impossible
+  // to bind a real Control shortcut on macOS.
+  if (isMac ? event.metaKey : event.ctrlKey) {
+    tokens.push("Mod");
+  }
+  if (isMac ? event.ctrlKey : event.metaKey) {
+    tokens.push(isMac ? "Ctrl" : "Super");
+  }
+  if (event.altKey) {
+    tokens.push("Alt");
+  }
+  if (event.shiftKey) {
+    tokens.push("Shift");
+  }
+  tokens.push(mainKey);
+
+  return tokens.join("+");
+}

--- a/src/shared/locales/en/translation.json
+++ b/src/shared/locales/en/translation.json
@@ -356,7 +356,12 @@
         ]
       },
       "toast": {
-        "reset": "Keyboard shortcuts restored."
+        "reset": "Keyboard shortcuts restored.",
+        "copy_permission": "AIctionary needs permission to copy the selected text. Grant it under Privacy & Security → Automation, then try again.",
+        "copy_unavailable": "Could not copy the selected text from the active app.",
+        "copy_empty": "Nothing was selected, and the clipboard is empty.",
+        "open_settings": "Open settings",
+        "register_failed": "The system refused to register {{shortcut}} — it is probably already taken. Pick another one."
       }
     },
     "about": {

--- a/src/shared/locales/zh/translation.json
+++ b/src/shared/locales/zh/translation.json
@@ -356,7 +356,12 @@
         ]
       },
       "toast": {
-        "reset": "键盘快捷键已恢复。"
+        "reset": "键盘快捷键已恢复。",
+        "copy_permission": "AIctionary 需要授权才能复制选中的文本。请在「隐私与安全性 → 自动化」中授权后重试。",
+        "copy_unavailable": "无法从当前应用复制选中的文本。",
+        "copy_empty": "没有选中内容，剪贴板也是空的。",
+        "open_settings": "打开设置",
+        "register_failed": "系统拒绝注册 {{shortcut}}，可能已被占用，请换一个。"
       }
     },
     "about": {

--- a/src/shared/state/settings.ts
+++ b/src/shared/state/settings.ts
@@ -1,6 +1,18 @@
 import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
-import { AppSettings, AudioSettings } from "@/shared/types/settings";
+import {
+  AppSettings,
+  AudioSettings,
+  KeyboardShortcutSettings,
+} from "@/shared/types/settings";
+
+/**
+ * The original quick query default. A global hotkey outranks the focused
+ * application, so binding Command/Ctrl+Enter took that chord away from every
+ * other app while AIctionary ran. Installs still carrying the old default
+ * move to the new one; anything the user picked themselves is left alone.
+ */
+const LEGACY_QUICK_QUERY_DEFAULT = "Mod+Enter";
 
 export const defaultSettings: AppSettings = {
   theme: {
@@ -39,7 +51,7 @@ export const defaultSettings: AppSettings = {
     lastUpdated: null,
   },
   keyboard: {
-    quickQuery: "Mod+Enter",
+    quickQuery: "Mod+Shift+D",
     newQuery: "Mod+Shift+K",
     enabled: true,
   },
@@ -65,6 +77,21 @@ export const updateSettingsAtom = atom(
     set(settingsAtom, { ...get(settingsAtom), ...update });
   }
 );
+
+/** Retire the old quick query default without touching custom bindings. */
+export function normalizeKeyboardSettings(
+  value: Partial<KeyboardShortcutSettings> | undefined
+): KeyboardShortcutSettings {
+  const merged = { ...defaultSettings.keyboard, ...(value ?? {}) };
+
+  return {
+    ...merged,
+    quickQuery:
+      merged.quickQuery === LEGACY_QUICK_QUERY_DEFAULT
+        ? defaultSettings.keyboard.quickQuery
+        : merged.quickQuery,
+  };
+}
 
 /**
  * Bring stored audio settings up to the current per-provider shape. Older


### PR DESCRIPTION
Five separate defects were stacking up into "the shortcuts sometimes just don't work".

## 1. macOS never asked for the permission quick query needs

Quick query synthesises `Command+C` in the frontmost app through System Events, which macOS gates behind Automation consent. The bundle shipped no `Info.plist`, and without `NSAppleEventsUsageDescription` macOS denies the Apple Event outright — it does not even prompt. The failure was then discarded (`let _ = …status()`), and with an empty clipboard the handler returned *before* showing the window, so the shortcut produced no feedback at all.

Now: `src-tauri/Info.plist` declares the usage description, the `osascript` failure is classified (permission vs. unavailable), the window is raised unconditionally, and the frontend gets a payload it can explain — with an action button that opens the right settings pane.

## 2. Event listeners re-subscribed on every render

`useGlobalShortcuts` keyed its two `listen()` effects on `onQuickQuery` / `onNewQuery`, which `AppLayout` passed as inline arrows. `AppLayout` reads four Jotai atoms, so it re-renders on every search, settings change and navigation. Registration crosses the IPC boundary asynchronously, so each cycle left a window with no backend listener and events emitted in it were dropped silently — the intermittent failures.

Callbacks now live in a ref; the listeners register once for the app's lifetime.

## 3. Focusing a minimised window is a no-op

`shortcuts.rs` did show → `set_focus` → `unminimize`, so pressing a shortcut while minimised restored the window *unfocused* and the caret never reached the query bar. `tray.rs` already had the right order.

## 4. Registration failures were invisible

A parse failure on one accelerator aborted both registrations, and the only reporting was `console.error`. An accelerator the OS refuses (already owned by another app) kept looking bound in settings while doing nothing. Registration is now per-shortcut and the outcome is reported to the UI.

## 5. "Mod" was never translated for the platform, and Ctrl/Cmd were conflated

Registration always resolved `Mod` per platform, but the settings UI rendered the raw token, so users saw a literal `Mod` chip. Chips and placeholders now show what the platform actually presses (⌘⇧D on macOS, Ctrl+Shift+D elsewhere).

Capture pushed `"Mod"` for `ctrlKey || metaKey`, so a Control shortcut on macOS was silently stored as Command. The two are now bound separately, and the main key is read from `event.code` rather than `event.key` — the latter reports the character the modifiers produced (`Alt+K` arrives as `˚` on macOS, which no hotkey parser accepts).

## Default change

Quick query defaulted to `Mod+Enter`. A global hotkey outranks the focused app, so that took Command+Enter away from every other application while AIctionary ran. New default is `Mod+Shift+D`; installs still carrying the old default are migrated, custom bindings are untouched.

## Testing

`npx tsc --noEmit`, `vite build`, `cargo test --lib` (4 new tests over accelerator normalisation) and `cargo clippy --all-targets` all pass — clippy reports no warnings in the touched files.

Not verified at runtime. In particular the macOS permission path cannot be exercised under `tauri dev`, which runs an unbundled binary with no `Info.plist` — it needs `bun tauri build` to test.